### PR TITLE
Update redis store setup sprint-5

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -122,6 +122,7 @@ jobs:
           export JWT_SECRET=${{ secrets.JWT_SECRET }}
           export AUTH_SERVICE_IP=${{ vars.DROPLET_IP }}
           export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+          export REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
           docker compose down
           docker compose pull
           docker compose up -d

--- a/auth-service/src/lib.rs
+++ b/auth-service/src/lib.rs
@@ -12,9 +12,12 @@ use domain::AuthAPIError;
 use redis::{Client, RedisResult};
 use routes::{login, logout, signup, verify_2fa, verify_token};
 use serde::{Deserialize, Serialize};
-use tower_http::{cors::CorsLayer, services::{ServeDir, ServeFile}};
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use tokio::net::TcpListener;
+use tower_http::{
+    cors::CorsLayer,
+    services::{ServeDir, ServeFile},
+};
 
 pub mod app_state;
 pub mod domain;
@@ -29,8 +32,8 @@ pub struct Application {
 
 impl Application {
     pub async fn build(app_state: AppState, address: &str) -> Result<Self, Box<dyn Error>> {
-        let asset_dir = ServeDir::new("assets")
-            .not_found_service(ServeFile::new("assets/index.html"));
+        let asset_dir =
+            ServeDir::new("assets").not_found_service(ServeFile::new("assets/index.html"));
         let allowed_origins = [
             "http://localhost:8000".parse()?,
             "http://[YOUR_DROPLET_IP]:8000".parse()?,
@@ -94,7 +97,18 @@ pub async fn get_postgres_pool(url: &str) -> Result<PgPool, sqlx::Error> {
     PgPoolOptions::new().max_connections(5).connect(url).await
 }
 
-pub fn get_redis_client(redis_hostname: String) -> RedisResult<Client> {
-    let redis_url = format!("redis://{}/", redis_hostname);
+pub fn get_redis_client(
+    redis_hostname: &String,
+    redis_password: Option<&String>,
+) -> RedisResult<Client> {
+    let redis_url = match redis_password {
+        Some(password) => {
+            format!("redis://:{}@{}/",password, redis_hostname)
+        }
+        None => {
+            format!("redis://{}/", redis_hostname)
+        }
+    };
+
     redis::Client::open(redis_url)
 }

--- a/auth-service/src/main.rs
+++ b/auth-service/src/main.rs
@@ -9,7 +9,7 @@ use auth_service::{
         data_stores::{PostgresUserStore, RedisBannedTokenStore, RedisTwoFACodeStore},
         mock_email_client::MockEmailClient,
     },
-    utils::constants::{prod, DATABASE_URL, REDIS_HOST_NAME},
+    utils::constants::{prod, DATABASE_URL, REDIS_HOST_NAME, REDIS_PASSWORD},
     Application,
 };
 
@@ -54,7 +54,7 @@ async fn configure_postgresql() -> PgPool {
 }
 
 fn configure_redis() -> redis::Connection {
-    get_redis_client(REDIS_HOST_NAME.to_owned())
+    get_redis_client(&REDIS_HOST_NAME, REDIS_PASSWORD.as_ref())
         .expect("Failed to get Redis client")
         .get_connection()
         .expect("Failed to get Redis connection")

--- a/auth-service/src/utils/constants.rs
+++ b/auth-service/src/utils/constants.rs
@@ -6,6 +6,7 @@ lazy_static! {
     pub static ref JWT_SECRET: String = set_token();
     pub static ref DATABASE_URL: String = set_db_url();
     pub static ref REDIS_HOST_NAME: String = set_redis_host();
+    pub static ref REDIS_PASSWORD: Option<String> = set_redis_password();
 }
 
 fn set_token() -> String {
@@ -27,10 +28,20 @@ fn set_redis_host() -> String {
     std_env::var(env::REDIS_HOST_NAME_ENV_VAR).unwrap_or(DEFAULT_REDIS_HOSTNAME.to_owned())
 }
 
+fn set_redis_password() -> Option<String> {
+    dotenv().ok();
+
+    std_env::var("REDIS_PASSWORD")
+        .ok()
+        .filter(|password| !password.is_empty())
+        .map(|password| password)
+}
+
 pub mod env {
     pub const DATABASE_URL_ENV_VAR: &str = "DATABASE_URL";
     pub const JWT_SECRET_ENV_VAR: &str = "JWT_SECRET";
     pub const REDIS_HOST_NAME_ENV_VAR: &str = "REDIS_HOST_NAME";
+    pub const REDIS_PASSWORD_ENV_VAR: &str = "REDIS_PASSWORD";
 }
 
 pub const JWT_COOKIE_NAME: &str = "jwt";

--- a/auth-service/tests/api/helpers.rs
+++ b/auth-service/tests/api/helpers.rs
@@ -14,7 +14,7 @@ use auth_service::{
         data_stores::{PostgresUserStore, RedisBannedTokenStore, RedisTwoFACodeStore},
         mock_email_client::MockEmailClient,
     },
-    utils::constants::{test, DATABASE_URL, DEFAULT_REDIS_HOSTNAME},
+    utils::constants::{test, DATABASE_URL, DEFAULT_REDIS_HOSTNAME, REDIS_PASSWORD},
     Application,
 };
 
@@ -239,8 +239,8 @@ async fn configure_database(db_conn_string: &str, db_name: &str) {
 
 fn configure_redis() -> redis::Connection {
     let redis_hostname = DEFAULT_REDIS_HOSTNAME.to_owned();
-
-    get_redis_client(redis_hostname)
+    let redis_password = REDIS_PASSWORD.as_ref();
+    get_redis_client(&redis_hostname, redis_password)
         .expect("Failed to get Redis client")
         .get_connection()
         .expect("Failed to get Redis connection")

--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       AUTH_SERVICE_IP: ${AUTH_SERVICE_IP}
     ports:
-      - "8000:8000" # expose port 8000 so that applications outside the container can connect to it 
+      - "8000:8000" # expose port 8000 so that applications outside the container can connect to it
     depends_on: # only run app-service after auth-service has started
       auth-service:
         condition: service_started
@@ -16,10 +16,12 @@ services:
     environment:
       JWT_SECRET: ${JWT_SECRET}
       DATABASE_URL: "postgres://postgres:${POSTGRES_PASSWORD}@db:5432"
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
     ports:
       - "3000:3000" # expose port 3000 so that applications outside the container can connect to it
     depends_on:
       - db
+      - redis
   db:
     image: postgres:15.2-alpine
     restart: always
@@ -31,9 +33,10 @@ services:
       - db:/var/lib/postgresql/data
   redis:
     image: redis:7.0-alpine
+    command: redis-server --requirepass ${REDIS_PASSWORD}
     restart: always
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
 
 volumes:
   db:


### PR DESCRIPTION
### What does this PR do?
Closes https://github.com/letsgetrusty/live-bootcamp-project/issues/68
1. Bind Redis to localhost only, so only services on the same machine (your app containers) can reach it.
2. Set a Redis password

### ClickUp updates

- [Add Redis service to `compose.yml`](https://app.clickup.com/9015495369/v/dc/8cnv2p9-25035?pr=90151652890&block=block-06fc2f11-22c2-4f90-93cb-b1dc8c398d64)
- [Add `REDIS_PASSWORD` to `auth-service/.env`]( https://app.clickup.com/9015495369/v/dc/8cnv2p9-25035?pr=90151652890&block=block-7J70EudMQK)
- [Add `get_redis_client` helper function to `auth-service/src/lib.rs`](https://app.clickup.com/9015495369/v/dc/8cnv2p9-25035?pr=90151652890&block=block-38c2dfbf-bcf1-4777-9111-c8dd7b09590c)
- [Add `REDIS_HOST_NAME`, `REDIS_HOST_NAME_ENV_VAR`, `DEFAULT_REDIS_HOSTNAME`, `REDIS_PASSWORD` and `REDIS_PASSWORD_ENV_VAR` to `auth-service/src/utils/constants.rs`](https://app.clickup.com/9015495369/v/dc/8cnv2p9-25035?pr=90151652890&block=block-a0e70b5c-0c96-4a06-8b1b-da4c9805ac5b)
- [Add `REDIS_HOST_NAME` to `auth-service/Dockerfile`](https://app.clickup.com/9015495369/v/dc/8cnv2p9-25035?pr=90151652890&block=block-37fdcba6-f4a5-41fa-9163-93a0f0c2a3b3)
- [Add `configure_redis` helper function to `auth-service/src/main.rs`](https://app.clickup.com/9015495369/v/dc/8cnv2p9-25035?pr=90151652890&block=block-06bd31ac-7121-464e-8fc1-e6a2ec79f8a7)
- [Verify all integration tests are passing](https://app.clickup.com/9015495369/v/dc/8cnv2p9-25035?pr=90151652890&block=block-c187e035-845d-45dc-87ed-eaa3d51d2e77)
- [Verify all integration tests are passing](https://app.clickup.com/9015495369/v/dc/8cnv2p9-25035?pr=90151652890&block=block-2c7bb3fb-d99a-4368-8e5b-209905e7e021)
- [Update .github/workflows/prod.yml](https://app.clickup.com/9015495369/v/dc/8cnv2p9-25035/8cnv2p9-44615?block=block-45709064-4409-4b96-912b-9f02c2b8e1f5)