### PR TITLE
Update redis setup sprint 6

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -122,6 +122,7 @@ jobs:
           export JWT_SECRET=${{ secrets.JWT_SECRET }}
           export AUTH_SERVICE_IP=${{ vars.DROPLET_IP }}
           export POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+          export REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
           export RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
           docker compose down
           docker compose pull

--- a/auth-service/src/lib.rs
+++ b/auth-service/src/lib.rs
@@ -111,8 +111,19 @@ pub async fn get_postgres_pool(url: &SecretString) -> Result<PgPool, sqlx::Error
         .await
 }
 
-pub fn get_redis_client(redis_hostname: String) -> RedisResult<Client> {
-    let redis_url = format!("redis://{}/", redis_hostname);
+pub fn get_redis_client(
+    redis_hostname: &String,
+    redis_password: Option<&SecretString>,
+) -> RedisResult<Client> {
+    let redis_url = match redis_password {
+        Some(password) => {
+            format!("redis://:{}@{}/", password.expose_secret(), redis_hostname)
+        }
+        None => {
+            format!("redis://{}/", redis_hostname)
+        }
+    };
+
     redis::Client::open(redis_url)
 }
 

--- a/auth-service/src/main.rs
+++ b/auth-service/src/main.rs
@@ -13,7 +13,7 @@ use auth_service::{
         resend_email_client::ResendEmailClient,
     },
     utils::{
-        constants::{prod, DATABASE_URL, REDIS_HOST_NAME, RESEND_API_KEY},
+        constants::{prod, DATABASE_URL, REDIS_HOST_NAME, REDIS_PASSWORD, RESEND_API_KEY},
         tracing::init_tracing,
     },
     Application,
@@ -63,7 +63,7 @@ async fn configure_postgresql() -> PgPool {
 }
 
 fn configure_redis() -> redis::Connection {
-    get_redis_client(REDIS_HOST_NAME.to_owned())
+    get_redis_client(&REDIS_HOST_NAME, REDIS_PASSWORD.as_ref())
         .expect("Failed to get Redis client")
         .get_connection()
         .expect("Failed to get Redis connection")

--- a/auth-service/src/utils/constants.rs
+++ b/auth-service/src/utils/constants.rs
@@ -7,6 +7,7 @@ lazy_static! {
     pub static ref JWT_SECRET: SecretString = set_token();
     pub static ref DATABASE_URL: SecretString = set_db_url();
     pub static ref REDIS_HOST_NAME: String = set_redis_host();
+    pub static ref REDIS_PASSWORD: Option<SecretString> = set_redis_password();
     pub static ref RESEND_API_KEY: SecretString = set_resend_auth_token();
 }
 
@@ -33,6 +34,15 @@ fn set_redis_host() -> String {
     std_env::var(env::REDIS_HOST_NAME_ENV_VAR).unwrap_or(DEFAULT_REDIS_HOSTNAME.to_owned())
 }
 
+fn set_redis_password() -> Option<SecretString> {
+    dotenv().ok();
+
+    std_env::var("REDIS_PASSWORD")
+        .ok()
+        .filter(|password| !password.is_empty())
+        .map(|password| SecretString::new(password.into_boxed_str()))
+}
+
 fn set_resend_auth_token() -> SecretString {
     dotenv().ok();
     SecretString::new(
@@ -46,6 +56,7 @@ pub mod env {
     pub const DATABASE_URL_ENV_VAR: &str = "DATABASE_URL";
     pub const JWT_SECRET_ENV_VAR: &str = "JWT_SECRET";
     pub const REDIS_HOST_NAME_ENV_VAR: &str = "REDIS_HOST_NAME";
+    pub const REDIS_PASSWORD_ENV_VAR: &str = "REDIS_PASSWORD";
     pub const RESEND_AUTH_TOKEN_ENV_VAR: &str = "RESEND_API_KEY";
 }
 

--- a/auth-service/tests/api/helpers.rs
+++ b/auth-service/tests/api/helpers.rs
@@ -17,7 +17,7 @@ use auth_service::{
         data_stores::{PostgresUserStore, RedisBannedTokenStore, RedisTwoFACodeStore},
         resend_email_client::ResendEmailClient,
     },
-    utils::constants::{test, DATABASE_URL, DEFAULT_REDIS_HOSTNAME},
+    utils::constants::{test, DATABASE_URL, DEFAULT_REDIS_HOSTNAME, REDIS_PASSWORD},
     Application,
 };
 
@@ -248,8 +248,9 @@ async fn configure_database(db_conn_string: &SecretString, db_name: &str) {
 
 fn configure_redis() -> redis::Connection {
     let redis_hostname = DEFAULT_REDIS_HOSTNAME.to_owned();
+    let redis_pass = REDIS_PASSWORD.as_ref();
 
-    get_redis_client(redis_hostname)
+    get_redis_client(&redis_hostname, redis_pass)
         .expect("Failed to get Redis client")
         .get_connection()
         .expect("Failed to get Redis connection")

--- a/compose.yml
+++ b/compose.yml
@@ -16,11 +16,13 @@ services:
     environment:
       JWT_SECRET: ${JWT_SECRET}
       DATABASE_URL: "postgres://postgres:${POSTGRES_PASSWORD}@db:5432"
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
       RESEND_API_KEY: ${RESEND_API_KEY}
     ports:
       - "3000:3000" # expose port 3000 so that applications outside the container can connect to it
     depends_on:
       - db
+      - redis
   db:
     image: postgres:15.2-alpine
     restart: always
@@ -32,9 +34,10 @@ services:
       - db:/var/lib/postgresql/data
   redis:
     image: redis:7.0-alpine
+    command: redis-server --requirepass ${REDIS_PASSWORD}
     restart: always
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
 
 volumes:
   db:


### PR DESCRIPTION
### What does this PR do?
Closes https://github.com/letsgetrusty/live-bootcamp-project/issues/68
1. Bind Redis to localhost only, so only services on the same machine (your app containers) can reach it.
2. Set a Redis password

### What still needs to be done?
- [x] Update ClickUp steps

[Add `RESEND_API_KEY` to auth-service in compose.yml ](https://app.clickup.com/9015495369/v/dc/8cnv2p9-24955/8cnv2p9-44495?block=block-06fc2f11-22c2-4f90-93cb-b1dc8c398d64)

[Add RESEND_API_KEY to the Deploy job in .github/workflow/prod.yml](https://app.clickup.com/9015495369/v/dc/8cnv2p9-24955/8cnv2p9-44495?block=block-c50768c4-c391-48b8-92ed-5aee2f3f9cc7)

[Add RESEND_API_KEY to auth-service/src/utils/constants.rs](https://app.clickup.com/9015495369/v/dc/8cnv2p9-24955/8cnv2p9-44495?block=block-6d6f2624-922d-4ec5-ac50-c5cf8c2979da)
