### PR TITLE
Sprint 3: Update alpine version and logout & login return type

### DIFF
--- a/app-service/Dockerfile
+++ b/app-service/Dockerfile
@@ -1,5 +1,5 @@
 # Start with image that has the Rust toolchain installed
-FROM rust:1.90-alpine AS chef
+FROM rust:1.91-alpine AS chef
 USER root
 # Add cargo-chef to cache dependencies
 RUN apk add --no-cache musl-dev & cargo install cargo-chef

--- a/app-service/Dockerfile
+++ b/app-service/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.91-alpine AS chef
 USER root
 # Add cargo-chef to cache dependencies
-RUN apk add --no-cache musl-dev & cargo install cargo-chef
+RUN apk add --no-cache musl-dev && cargo install cargo-chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/app-service/Dockerfile
+++ b/app-service/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.91-alpine AS chef
 USER root
 # Add cargo-chef to cache dependencies
-RUN apk add --no-cache musl-dev && cargo install cargo-chef
+RUN apk add --no-cache musl-dev && cargo install cargo-chef --locked
 WORKDIR /app
 
 FROM chef AS planner

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,5 +1,5 @@
 # Start with image that has the Rust toolchain installed
-FROM rust:1.90-alpine AS chef
+FROM rust:1.91-alpine AS chef
 USER root
 # Add cargo-chef to cache dependencies
 RUN apk add --no-cache musl-dev & cargo install cargo-chef

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.91-alpine AS chef
 USER root
 # Add cargo-chef to cache dependencies
-RUN apk add --no-cache musl-dev & cargo install cargo-chef
+RUN apk add --no-cache musl-dev && cargo install cargo-chef --locked
 WORKDIR /app
 
 FROM chef AS planner

--- a/auth-service/src/routes/login.rs
+++ b/auth-service/src/routes/login.rs
@@ -12,36 +12,36 @@ pub async fn login(
     State(state): State<AppState>,
     jar: CookieJar,
     Json(request): Json<LoginRequest>,
-) -> (CookieJar, Result<impl IntoResponse, AuthAPIError>) {
+) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
     let password = match Password::parse(request.password) {
         Ok(password) => password,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidCredentials)),
+        Err(_) => return Err(AuthAPIError::InvalidCredentials),
     };
 
     let email = match Email::parse(request.email) {
         Ok(email) => email,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidCredentials)),
+        Err(_) => return Err(AuthAPIError::InvalidCredentials),
     };
 
     let user_store = &state.user_store.read().await;
 
     if user_store.validate_user(&email, &password).await.is_err() {
-        return (jar, Err(AuthAPIError::IncorrectCredentials));
+        return Err(AuthAPIError::IncorrectCredentials);
     }
 
     let user = match user_store.get_user(&email).await {
         Ok(user) => user,
-        Err(_) => return (jar, Err(AuthAPIError::IncorrectCredentials)),
+        Err(_) => return Err(AuthAPIError::IncorrectCredentials),
     };
 
     let auth_cookie = match generate_auth_cookie(&user.email) {
         Ok(cookie) => cookie,
-        Err(_) => return (jar, Err(AuthAPIError::UnexpectedError)),
+        Err(_) => return Err(AuthAPIError::UnexpectedError),
     };
 
     let updated_jar = jar.add(auth_cookie);
 
-    (updated_jar, Ok(StatusCode::OK.into_response()))
+    Ok((updated_jar, StatusCode::OK.into_response()))
 }
 
 #[derive(Deserialize)]

--- a/auth-service/src/routes/login.rs
+++ b/auth-service/src/routes/login.rs
@@ -20,9 +20,10 @@ pub async fn login(
 
     let user_store = &state.user_store.read().await;
 
-    if user_store.validate_user(&email, &password).await.is_err() {
-        return Err(AuthAPIError::IncorrectCredentials);
-    }
+    user_store
+        .validate_user(&email, &password)
+        .await
+        .map_err(|_| AuthAPIError::IncorrectCredentials)?;
 
     let user = user_store
         .get_user(&email)

--- a/auth-service/src/routes/login.rs
+++ b/auth-service/src/routes/login.rs
@@ -13,15 +13,10 @@ pub async fn login(
     jar: CookieJar,
     Json(request): Json<LoginRequest>,
 ) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
-    let password = match Password::parse(request.password) {
-        Ok(password) => password,
-        Err(_) => return Err(AuthAPIError::InvalidCredentials),
-    };
+    let password =
+        Password::parse(request.password).map_err(|_| AuthAPIError::InvalidCredentials)?;
 
-    let email = match Email::parse(request.email) {
-        Ok(email) => email,
-        Err(_) => return Err(AuthAPIError::InvalidCredentials),
-    };
+    let email = Email::parse(request.email).map_err(|_| AuthAPIError::InvalidCredentials)?;
 
     let user_store = &state.user_store.read().await;
 
@@ -29,15 +24,13 @@ pub async fn login(
         return Err(AuthAPIError::IncorrectCredentials);
     }
 
-    let user = match user_store.get_user(&email).await {
-        Ok(user) => user,
-        Err(_) => return Err(AuthAPIError::IncorrectCredentials),
-    };
+    let user = user_store
+        .get_user(&email)
+        .await
+        .map_err(|_| AuthAPIError::IncorrectCredentials)?;
 
-    let auth_cookie = match generate_auth_cookie(&user.email) {
-        Ok(cookie) => cookie,
-        Err(_) => return Err(AuthAPIError::UnexpectedError),
-    };
+    let auth_cookie =
+        generate_auth_cookie(&user.email).map_err(|_| AuthAPIError::UnexpectedError)?;
 
     let updated_jar = jar.add(auth_cookie);
 

--- a/auth-service/src/routes/logout.rs
+++ b/auth-service/src/routes/logout.rs
@@ -10,17 +10,17 @@ use crate::{
 pub async fn logout(
     State(state): State<AppState>,
     jar: CookieJar,
-) -> (CookieJar, Result<impl IntoResponse, AuthAPIError>) {
+) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
     let cookie = match jar.get(JWT_COOKIE_NAME) {
         Some(cookie) => cookie,
-        None => return (jar, Err(AuthAPIError::MissingToken)),
+        None => return Err(AuthAPIError::MissingToken),
     };
 
     // Validate token
     let token = cookie.value().to_owned();
     let _ = match validate_token(&token, state.banned_token_store.clone()).await {
         Ok(claims) => claims,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidToken)),
+        Err(_) => return Err(AuthAPIError::InvalidToken),
     };
 
     // Add token to banned list
@@ -32,11 +32,11 @@ pub async fn logout(
         .await
         .is_err()
     {
-        return (jar, Err(AuthAPIError::UnexpectedError));
+        return Err(AuthAPIError::UnexpectedError);
     }
 
     // Remove jwt cookie
     let jar = jar.remove(cookie::Cookie::from(JWT_COOKIE_NAME));
 
-    (jar, Ok(StatusCode::OK))
+    Ok((jar, StatusCode::OK))
 }

--- a/auth-service/src/routes/logout.rs
+++ b/auth-service/src/routes/logout.rs
@@ -11,29 +11,22 @@ pub async fn logout(
     State(state): State<AppState>,
     jar: CookieJar,
 ) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
-    let cookie = match jar.get(JWT_COOKIE_NAME) {
-        Some(cookie) => cookie,
-        None => return Err(AuthAPIError::MissingToken),
-    };
+    let cookie = jar.get(JWT_COOKIE_NAME).ok_or(AuthAPIError::MissingToken)?;
 
     // Validate token
     let token = cookie.value().to_owned();
-    let _ = match validate_token(&token, state.banned_token_store.clone()).await {
-        Ok(claims) => claims,
-        Err(_) => return Err(AuthAPIError::InvalidToken),
-    };
+    validate_token(&token, state.banned_token_store.clone())
+        .await
+        .map_err(|_| AuthAPIError::InvalidToken)?;
 
     // Add token to banned list
-    if state
+    state
         .banned_token_store
         .write()
         .await
-        .add_token(token.to_owned())
+        .add_token(token)
         .await
-        .is_err()
-    {
-        return Err(AuthAPIError::UnexpectedError);
-    }
+        .map_err(|_| AuthAPIError::UnexpectedError)?;
 
     // Remove jwt cookie
     let jar = jar.remove(cookie::Cookie::from(JWT_COOKIE_NAME));


### PR DESCRIPTION
What does this PR do?
Updates the return types for login and logout route functions addressed in #37

Why the Dockerfile changes? 
`cargo-chef`'s dependency `cargo-platform@0.3.3` requires `rustc 1.91`, so the build failed on `rust:1.90-alpine`. Bumped to `1.91` and added `--locked` to pin `cargo-chef` to its lockfile, preventing future dependency resolution surprises.

What are the related ClickUp changes?

- Updated `auth-service/src/routes/login.rs`
[Update return type](https://app.clickup.com/9015495369/v/dc/8cnv2p9-25015/8cnv2p9-44555?block=block-59cb3c11-f5ee-4931-9070-60e1294fa2d0)

- Updated `auth-service/src/routes/logout.rs`
[Update return type](https://app.clickup.com/9015495369/v/dc/8cnv2p9-25015/8cnv2p9-44555?block=block-ef27e492-8e48-448a-8a52-b552adf08d03)

