### PR TITLE
Sprint-4: update alpine version and logout & login return type

### DIFF
--- a/app-service/Dockerfile
+++ b/app-service/Dockerfile
@@ -1,10 +1,8 @@
 # Start with image that has the Rust toolchain installed
-FROM rust:1.90-alpine AS chef
+FROM rust:1.91-alpine AS chef
 USER root
 # Add cargo-chef to cache dependencies
-RUN apk add --no-cache musl-dev
-RUN rustup update stable
-RUN cargo install cargo-chef --locked
+RUN apk add --no-cache musl-dev && cargo install cargo-chef --locked
 WORKDIR /app
 
 FROM chef AS planner

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,10 +1,8 @@
 # Start with image that has the Rust toolchain installed
-FROM rust:1.90-alpine AS chef
+FROM rust:1.91-alpine AS chef
 USER root
 # Add cargo-chef to cache dependencies
-RUN apk add --no-cache musl-dev
-RUN rustup update stable
-RUN cargo install cargo-chef --locked
+RUN apk add --no-cache musl-dev && cargo install cargo-chef --locked
 WORKDIR /app
 
 FROM chef AS planner

--- a/auth-service/src/routes/login.rs
+++ b/auth-service/src/routes/login.rs
@@ -1,4 +1,9 @@
-use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
 use axum_extra::extract::CookieJar;
 use serde::{Deserialize, Serialize};
 
@@ -12,26 +17,26 @@ pub async fn login(
     State(state): State<AppState>,
     jar: CookieJar,
     Json(request): Json<LoginRequest>,
-) -> (CookieJar, Result<impl IntoResponse, AuthAPIError>) {
+) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
     let password = match Password::parse(request.password) {
         Ok(password) => password,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidCredentials)),
+        Err(_) => return Err(AuthAPIError::InvalidCredentials),
     };
 
     let email = match Email::parse(request.email) {
         Ok(email) => email,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidCredentials)),
+        Err(_) => return Err(AuthAPIError::InvalidCredentials),
     };
 
     let user_store = &state.user_store.read().await;
 
     if user_store.validate_user(&email, &password).await.is_err() {
-        return (jar, Err(AuthAPIError::IncorrectCredentials));
+        return Err(AuthAPIError::IncorrectCredentials);
     }
 
     let user = match user_store.get_user(&email).await {
         Ok(user) => user,
-        Err(_) => return (jar, Err(AuthAPIError::IncorrectCredentials)),
+        Err(_) => return Err(AuthAPIError::IncorrectCredentials),
     };
 
     match user.requires_2fa {
@@ -44,10 +49,7 @@ async fn handle_2fa(
     email: &Email,
     state: &AppState,
     jar: CookieJar,
-) -> (
-    CookieJar,
-    Result<(StatusCode, Json<LoginResponse>), AuthAPIError>,
-) {
+) -> Result<(CookieJar, Response), AuthAPIError> {
     let login_attempt_id = LoginAttemptId::default();
     let two_fa_code = TwoFACode::default();
 
@@ -59,7 +61,7 @@ async fn handle_2fa(
         .await
         .is_err()
     {
-        return (jar, Err(AuthAPIError::UnexpectedError));
+        return Err(AuthAPIError::UnexpectedError);
     }
 
     if state
@@ -68,35 +70,34 @@ async fn handle_2fa(
         .await
         .is_err()
     {
-        return (jar, Err(AuthAPIError::UnexpectedError));
+        return Err(AuthAPIError::UnexpectedError);
     }
 
-    let response = Json(LoginResponse::TwoFactorAuth(TwoFactorAuthResponse {
-        message: "2FA required".to_owned(),
-        login_attempt_id: login_attempt_id.as_ref().to_owned(),
-    }));
+    let response = (
+        StatusCode::PARTIAL_CONTENT,
+        Json(LoginResponse::TwoFactorAuth(TwoFactorAuthResponse {
+            message: "2FA required".to_owned(),
+            login_attempt_id: login_attempt_id.as_ref().to_owned(),
+        })),
+    )
+        .into_response();
 
-    (jar, Ok((StatusCode::PARTIAL_CONTENT, response)))
+    Ok((jar, response))
 }
 
 async fn handle_no_2fa(
     email: &Email,
     jar: CookieJar,
-) -> (
-    CookieJar,
-    Result<(StatusCode, Json<LoginResponse>), AuthAPIError>,
-) {
+) -> Result<(CookieJar, Response), AuthAPIError> {
     let auth_cookie = match generate_auth_cookie(email) {
         Ok(cookie) => cookie,
-        Err(_) => return (jar, Err(AuthAPIError::UnexpectedError)),
+        Err(_) => return Err(AuthAPIError::UnexpectedError),
     };
 
     let updated_jar = jar.add(auth_cookie);
+    let response = (StatusCode::OK, Json(LoginResponse::RegularAuth)).into_response();
 
-    (
-        updated_jar,
-        Ok((StatusCode::OK, Json(LoginResponse::RegularAuth))),
-    )
+    Ok((updated_jar, response))
 }
 
 #[derive(Deserialize)]

--- a/auth-service/src/routes/login.rs
+++ b/auth-service/src/routes/login.rs
@@ -1,9 +1,4 @@
-use axum::{
-    extract::State,
-    http::StatusCode,
-    response::{IntoResponse, Response},
-    Json,
-};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use axum_extra::extract::CookieJar;
 use serde::{Deserialize, Serialize};
 
@@ -49,7 +44,7 @@ async fn handle_2fa(
     email: &Email,
     state: &AppState,
     jar: CookieJar,
-) -> Result<(CookieJar, Response), AuthAPIError> {
+) -> Result<(CookieJar, (StatusCode, Json<LoginResponse>)), AuthAPIError> {
     let login_attempt_id = LoginAttemptId::default();
     let two_fa_code = TwoFACode::default();
 
@@ -79,8 +74,7 @@ async fn handle_2fa(
             message: "2FA required".to_owned(),
             login_attempt_id: login_attempt_id.as_ref().to_owned(),
         })),
-    )
-        .into_response();
+    );
 
     Ok((jar, response))
 }
@@ -88,14 +82,14 @@ async fn handle_2fa(
 async fn handle_no_2fa(
     email: &Email,
     jar: CookieJar,
-) -> Result<(CookieJar, Response), AuthAPIError> {
+) -> Result<(CookieJar, (StatusCode, Json<LoginResponse>)), AuthAPIError> {
     let auth_cookie = match generate_auth_cookie(email) {
         Ok(cookie) => cookie,
         Err(_) => return Err(AuthAPIError::UnexpectedError),
     };
 
     let updated_jar = jar.add(auth_cookie);
-    let response = (StatusCode::OK, Json(LoginResponse::RegularAuth)).into_response();
+    let response = (StatusCode::OK, Json(LoginResponse::RegularAuth));
 
     Ok((updated_jar, response))
 }

--- a/auth-service/src/routes/login.rs
+++ b/auth-service/src/routes/login.rs
@@ -13,26 +13,22 @@ pub async fn login(
     jar: CookieJar,
     Json(request): Json<LoginRequest>,
 ) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
-    let password = match Password::parse(request.password) {
-        Ok(password) => password,
-        Err(_) => return Err(AuthAPIError::InvalidCredentials),
-    };
+    let password =
+        Password::parse(request.password).map_err(|_| AuthAPIError::InvalidCredentials)?;
 
-    let email = match Email::parse(request.email) {
-        Ok(email) => email,
-        Err(_) => return Err(AuthAPIError::InvalidCredentials),
-    };
+    let email = Email::parse(request.email).map_err(|_| AuthAPIError::InvalidCredentials)?;
 
     let user_store = &state.user_store.read().await;
 
-    if user_store.validate_user(&email, &password).await.is_err() {
-        return Err(AuthAPIError::IncorrectCredentials);
-    }
+    user_store
+        .validate_user(&email, &password)
+        .await
+        .map_err(|_| AuthAPIError::IncorrectCredentials)?;
 
-    let user = match user_store.get_user(&email).await {
-        Ok(user) => user,
-        Err(_) => return Err(AuthAPIError::IncorrectCredentials),
-    };
+    let user = user_store
+        .get_user(&email)
+        .await
+        .map_err(|_| AuthAPIError::IncorrectCredentials)?;
 
     match user.requires_2fa {
         true => handle_2fa(&user.email, &state, jar).await,
@@ -48,25 +44,19 @@ async fn handle_2fa(
     let login_attempt_id = LoginAttemptId::default();
     let two_fa_code = TwoFACode::default();
 
-    if state
+    state
         .two_fa_code_store
         .write()
         .await
         .add_code(email.clone(), login_attempt_id.clone(), two_fa_code.clone())
         .await
-        .is_err()
-    {
-        return Err(AuthAPIError::UnexpectedError);
-    }
+        .map_err(|_| AuthAPIError::UnexpectedError)?;
 
-    if state
+    state
         .email_client
         .send_email(email, "2FA Code", two_fa_code.as_ref())
         .await
-        .is_err()
-    {
-        return Err(AuthAPIError::UnexpectedError);
-    }
+        .map_err(|_| AuthAPIError::UnexpectedError)?;
 
     let response = (
         StatusCode::PARTIAL_CONTENT,
@@ -83,10 +73,7 @@ async fn handle_no_2fa(
     email: &Email,
     jar: CookieJar,
 ) -> Result<(CookieJar, (StatusCode, Json<LoginResponse>)), AuthAPIError> {
-    let auth_cookie = match generate_auth_cookie(email) {
-        Ok(cookie) => cookie,
-        Err(_) => return Err(AuthAPIError::UnexpectedError),
-    };
+    let auth_cookie = generate_auth_cookie(email).map_err(|_| AuthAPIError::UnexpectedError)?;
 
     let updated_jar = jar.add(auth_cookie);
     let response = (StatusCode::OK, Json(LoginResponse::RegularAuth));

--- a/auth-service/src/routes/logout.rs
+++ b/auth-service/src/routes/logout.rs
@@ -10,17 +10,17 @@ use crate::{
 pub async fn logout(
     State(state): State<AppState>,
     jar: CookieJar,
-) -> (CookieJar, Result<impl IntoResponse, AuthAPIError>) {
+) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
     let cookie = match jar.get(JWT_COOKIE_NAME) {
         Some(cookie) => cookie,
-        None => return (jar, Err(AuthAPIError::MissingToken)),
+        None => return Err(AuthAPIError::MissingToken),
     };
 
     // Validate token
     let token = cookie.value().to_owned();
     let _ = match validate_token(&token, state.banned_token_store.clone()).await {
         Ok(claims) => claims,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidToken)),
+        Err(_) => return Err(AuthAPIError::InvalidToken),
     };
 
     // Add token to banned list
@@ -32,11 +32,11 @@ pub async fn logout(
         .await
         .is_err()
     {
-        return (jar, Err(AuthAPIError::UnexpectedError));
+        return Err(AuthAPIError::UnexpectedError);
     }
 
     // Remove jwt cookie
     let jar = jar.remove(cookie::Cookie::from(JWT_COOKIE_NAME));
 
-    (jar, Ok(StatusCode::OK))
+    Ok((jar, StatusCode::OK))
 }

--- a/auth-service/src/routes/logout.rs
+++ b/auth-service/src/routes/logout.rs
@@ -11,29 +11,22 @@ pub async fn logout(
     State(state): State<AppState>,
     jar: CookieJar,
 ) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
-    let cookie = match jar.get(JWT_COOKIE_NAME) {
-        Some(cookie) => cookie,
-        None => return Err(AuthAPIError::MissingToken),
-    };
+    let cookie = jar.get(JWT_COOKIE_NAME).ok_or(AuthAPIError::MissingToken)?;
 
     // Validate token
     let token = cookie.value().to_owned();
-    let _ = match validate_token(&token, state.banned_token_store.clone()).await {
-        Ok(claims) => claims,
-        Err(_) => return Err(AuthAPIError::InvalidToken),
-    };
+    validate_token(&token, state.banned_token_store.clone())
+        .await
+        .map_err(|_| AuthAPIError::InvalidToken)?;
 
     // Add token to banned list
-    if state
+    state
         .banned_token_store
         .write()
         .await
         .add_token(token.to_owned())
         .await
-        .is_err()
-    {
-        return Err(AuthAPIError::UnexpectedError);
-    }
+        .map_err(|_| AuthAPIError::UnexpectedError)?;
 
     // Remove jwt cookie
     let jar = jar.remove(cookie::Cookie::from(JWT_COOKIE_NAME));

--- a/auth-service/src/routes/verify_2fa.rs
+++ b/auth-service/src/routes/verify_2fa.rs
@@ -12,45 +12,45 @@ pub async fn verify_2fa(
     State(state): State<AppState>,
     jar: CookieJar,
     Json(request): Json<Verify2FARequest>,
-) -> (CookieJar, Result<impl IntoResponse, AuthAPIError>) {
+) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
     let email = match Email::parse(request.email.clone()) {
         Ok(email) => email,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidCredentials)),
+        Err(_) => return Err(AuthAPIError::InvalidCredentials),
     };
 
     let login_attempt_id = match LoginAttemptId::parse(request.login_attempt_id.clone()) {
         Ok(login_attempt_id) => login_attempt_id,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidCredentials)),
+        Err(_) => return Err(AuthAPIError::InvalidCredentials),
     };
 
     let two_fa_code = match TwoFACode::parse(request.two_fa_code) {
         Ok(two_fa_code) => two_fa_code,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidCredentials)),
+        Err(_) => return Err(AuthAPIError::InvalidCredentials),
     };
 
     let mut two_fa_code_store = state.two_fa_code_store.write().await;
 
     let code_tuple = match two_fa_code_store.get_code(&email).await {
         Ok(code_tuple) => code_tuple,
-        Err(_) => return (jar, Err(AuthAPIError::IncorrectCredentials)),
+        Err(_) => return Err(AuthAPIError::IncorrectCredentials),
     };
 
     if !code_tuple.0.eq(&login_attempt_id) || !code_tuple.1.eq(&two_fa_code) {
-        return (jar, Err(AuthAPIError::IncorrectCredentials));
+        return Err(AuthAPIError::IncorrectCredentials);
     }
 
     if two_fa_code_store.remove_code(&email).await.is_err() {
-        return (jar, Err(AuthAPIError::UnexpectedError));
+        return Err(AuthAPIError::UnexpectedError);
     }
 
     let cookie = match generate_auth_cookie(&email) {
         Ok(cookie) => cookie,
-        Err(_) => return (jar, Err(AuthAPIError::UnexpectedError)),
+        Err(_) => return Err(AuthAPIError::UnexpectedError),
     };
 
     let updated_jar = jar.add(cookie);
 
-    (updated_jar, Ok(()))
+    Ok((updated_jar, ()))
 }
 
 #[derive(Debug, Deserialize)]

--- a/auth-service/src/routes/verify_2fa.rs
+++ b/auth-service/src/routes/verify_2fa.rs
@@ -13,40 +13,32 @@ pub async fn verify_2fa(
     jar: CookieJar,
     Json(request): Json<Verify2FARequest>,
 ) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
-    let email = match Email::parse(request.email.clone()) {
-        Ok(email) => email,
-        Err(_) => return Err(AuthAPIError::InvalidCredentials),
-    };
+    let email =
+        Email::parse(request.email.clone()).map_err(|_| AuthAPIError::InvalidCredentials)?;
 
-    let login_attempt_id = match LoginAttemptId::parse(request.login_attempt_id.clone()) {
-        Ok(login_attempt_id) => login_attempt_id,
-        Err(_) => return Err(AuthAPIError::InvalidCredentials),
-    };
+    let login_attempt_id = LoginAttemptId::parse(request.login_attempt_id.clone())
+        .map_err(|_| AuthAPIError::InvalidCredentials)?;
 
-    let two_fa_code = match TwoFACode::parse(request.two_fa_code) {
-        Ok(two_fa_code) => two_fa_code,
-        Err(_) => return Err(AuthAPIError::InvalidCredentials),
-    };
+    let two_fa_code =
+        TwoFACode::parse(request.two_fa_code).map_err(|_| AuthAPIError::InvalidCredentials)?;
 
     let mut two_fa_code_store = state.two_fa_code_store.write().await;
 
-    let code_tuple = match two_fa_code_store.get_code(&email).await {
-        Ok(code_tuple) => code_tuple,
-        Err(_) => return Err(AuthAPIError::IncorrectCredentials),
-    };
+    let code_tuple = two_fa_code_store
+        .get_code(&email)
+        .await
+        .map_err(|_| AuthAPIError::IncorrectCredentials)?;
 
     if !code_tuple.0.eq(&login_attempt_id) || !code_tuple.1.eq(&two_fa_code) {
         return Err(AuthAPIError::IncorrectCredentials);
     }
 
-    if two_fa_code_store.remove_code(&email).await.is_err() {
-        return Err(AuthAPIError::UnexpectedError);
-    }
+    two_fa_code_store
+        .remove_code(&email)
+        .await
+        .map_err(|_| AuthAPIError::UnexpectedError)?;
 
-    let cookie = match generate_auth_cookie(&email) {
-        Ok(cookie) => cookie,
-        Err(_) => return Err(AuthAPIError::UnexpectedError),
-    };
+    let cookie = generate_auth_cookie(&email).map_err(|_| AuthAPIError::UnexpectedError)?;
 
     let updated_jar = jar.add(cookie);
 


### PR DESCRIPTION
What does this PR do?
Updates the return types for login and logout route functions addressed in #37

Why the Dockerfile changes? 
`cargo-chef`'s dependency `cargo-platform@0.3.3` requires `rustc 1.91`, so the build failed on `rust:1.90-alpine`. Bumped to `1.91` and added `--locked` to pin `cargo-chef` to its lockfile, preventing future dependency resolution surprises.

What are the related ClickUp changes?

- Updated login route
[Update return type](https://app.clickup.com/9015495369/v/dc/8cnv2p9-25115/8cnv2p9-44735?block=block-4856d37b-228f-46b6-97c7-c007f018ceb1)
[update return type](https://app.clickup.com/9015495369/v/dc/8cnv2p9-25115/8cnv2p9-44735?block=block-750197d0-9648-409c-ba24-41d6ef354140)