### PR TITLE
Sprint 6: update alpine version and verify_2fa, logout & login return type

### DIFF
--- a/app-service/Dockerfile
+++ b/app-service/Dockerfile
@@ -1,10 +1,8 @@
 # Start with image that has the Rust toolchain installed
-FROM rust:1.90-alpine AS chef
+FROM rust:1.91-alpine AS chef
 USER root
 # Add cargo-chef to cache dependencies
-RUN apk add --no-cache musl-dev
-RUN rustup update stable
-RUN cargo install cargo-chef --locked
+RUN apk add --no-cache musl-dev && cargo install cargo-chef --locked
 WORKDIR /app
 
 FROM chef AS planner

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,10 +1,8 @@
 # Start with image that has the Rust toolchain installed
-FROM rust:1.90-alpine AS chef
+FROM rust:1.91-alpine AS chef
 USER root
 # Add cargo-chef to cache dependencies
-RUN apk add --no-cache musl-dev
-RUN rustup update stable
-RUN cargo install cargo-chef --locked
+RUN apk add --no-cache musl-dev && cargo install cargo-chef --locked
 WORKDIR /app
 
 FROM chef AS planner

--- a/auth-service/src/routes/login.rs
+++ b/auth-service/src/routes/login.rs
@@ -14,15 +14,15 @@ pub async fn login(
     State(state): State<AppState>,
     jar: CookieJar,
     Json(request): Json<LoginRequest>,
-) -> (CookieJar, Result<impl IntoResponse, AuthAPIError>) {
+) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
     match HashedPassword::parse(request.password.clone()).await {
         Ok(password) => password,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidCredentials)),
+        Err(_) => return Err(AuthAPIError::InvalidCredentials),
     };
 
     let email = match Email::parse(request.email) {
         Ok(email) => email,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidCredentials)),
+        Err(_) => return Err(AuthAPIError::InvalidCredentials),
     };
 
     let user_store = &state.user_store.read().await;
@@ -32,12 +32,12 @@ pub async fn login(
         .await
         .is_err()
     {
-        return (jar, Err(AuthAPIError::IncorrectCredentials));
+        return Err(AuthAPIError::IncorrectCredentials);
     }
 
     let user = match user_store.get_user(&email).await {
         Ok(user) => user,
-        Err(_) => return (jar, Err(AuthAPIError::IncorrectCredentials)),
+        Err(_) => return Err(AuthAPIError::IncorrectCredentials),
     };
 
     match user.requires_2fa {
@@ -51,10 +51,7 @@ async fn handle_2fa(
     email: &Email,
     state: &AppState,
     jar: CookieJar,
-) -> (
-    CookieJar,
-    Result<(StatusCode, Json<LoginResponse>), AuthAPIError>,
-) {
+) -> Result<(CookieJar, (StatusCode, Json<LoginResponse>)), AuthAPIError> {
     let login_attempt_id = LoginAttemptId::default();
     let two_fa_code = TwoFACode::default();
 
@@ -65,7 +62,7 @@ async fn handle_2fa(
         .add_code(email.clone(), login_attempt_id.clone(), two_fa_code.clone())
         .await
     {
-        return (jar, Err(AuthAPIError::UnexpectedError(e.into())));
+        return Err(AuthAPIError::UnexpectedError(e.into()));
     }
 
     if let Err(e) = state
@@ -73,7 +70,7 @@ async fn handle_2fa(
         .send_email(email, "2FA Code", two_fa_code.as_ref().expose_secret())
         .await
     {
-        return (jar, Err(AuthAPIError::UnexpectedError(e)));
+        return Err(AuthAPIError::UnexpectedError(e));
     }
 
     let response = Json(LoginResponse::TwoFactorAuth(TwoFactorAuthResponse {
@@ -81,28 +78,25 @@ async fn handle_2fa(
         login_attempt_id: login_attempt_id.as_ref().expose_secret().to_owned(),
     }));
 
-    (jar, Ok((StatusCode::PARTIAL_CONTENT, response)))
+    Ok((jar, (StatusCode::PARTIAL_CONTENT, response)))
 }
 
 #[tracing::instrument(name = "Handle non-2FA flow", skip_all)]
 async fn handle_no_2fa(
     email: &Email,
     jar: CookieJar,
-) -> (
-    CookieJar,
-    Result<(StatusCode, Json<LoginResponse>), AuthAPIError>,
-) {
+) -> Result<(CookieJar, (StatusCode, Json<LoginResponse>)), AuthAPIError> {
     let auth_cookie = match generate_auth_cookie(email) {
         Ok(cookie) => cookie,
-        Err(e) => return (jar, Err(AuthAPIError::UnexpectedError(e))),
+        Err(e) => return Err(AuthAPIError::UnexpectedError(e)),
     };
 
     let updated_jar = jar.add(auth_cookie);
 
-    (
+    Ok((
         updated_jar,
-        Ok((StatusCode::OK, Json(LoginResponse::RegularAuth))),
-    )
+        (StatusCode::OK, Json(LoginResponse::RegularAuth)),
+    ))
 }
 
 #[derive(Deserialize)]

--- a/auth-service/src/routes/login.rs
+++ b/auth-service/src/routes/login.rs
@@ -15,30 +15,23 @@ pub async fn login(
     jar: CookieJar,
     Json(request): Json<LoginRequest>,
 ) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
-    match HashedPassword::parse(request.password.clone()).await {
-        Ok(password) => password,
-        Err(_) => return Err(AuthAPIError::InvalidCredentials),
-    };
+    HashedPassword::parse(request.password.clone())
+        .await
+        .map_err(|_| AuthAPIError::InvalidCredentials)?;
 
-    let email = match Email::parse(request.email) {
-        Ok(email) => email,
-        Err(_) => return Err(AuthAPIError::InvalidCredentials),
-    };
+    let email = Email::parse(request.email).map_err(|_| AuthAPIError::InvalidCredentials)?;
 
     let user_store = &state.user_store.read().await;
 
-    if user_store
+    user_store
         .validate_user(&email, &request.password)
         .await
-        .is_err()
-    {
-        return Err(AuthAPIError::IncorrectCredentials);
-    }
+        .map_err(|_| AuthAPIError::IncorrectCredentials)?;
 
-    let user = match user_store.get_user(&email).await {
-        Ok(user) => user,
-        Err(_) => return Err(AuthAPIError::IncorrectCredentials),
-    };
+    let user = user_store
+        .get_user(&email)
+        .await
+        .map_err(|_| AuthAPIError::IncorrectCredentials)?;
 
     match user.requires_2fa {
         true => handle_2fa(&user.email, &state, jar).await,
@@ -55,23 +48,19 @@ async fn handle_2fa(
     let login_attempt_id = LoginAttemptId::default();
     let two_fa_code = TwoFACode::default();
 
-    if let Err(e) = state
+    state
         .two_fa_code_store
         .write()
         .await
         .add_code(email.clone(), login_attempt_id.clone(), two_fa_code.clone())
         .await
-    {
-        return Err(AuthAPIError::UnexpectedError(e.into()));
-    }
+        .map_err(|e| AuthAPIError::UnexpectedError(e.into()))?;
 
-    if let Err(e) = state
+    state
         .email_client
         .send_email(email, "2FA Code", two_fa_code.as_ref().expose_secret())
         .await
-    {
-        return Err(AuthAPIError::UnexpectedError(e));
-    }
+        .map_err(|e| AuthAPIError::UnexpectedError(e.into()))?;
 
     let response = Json(LoginResponse::TwoFactorAuth(TwoFactorAuthResponse {
         message: "2FA required".to_owned(),
@@ -86,10 +75,7 @@ async fn handle_no_2fa(
     email: &Email,
     jar: CookieJar,
 ) -> Result<(CookieJar, (StatusCode, Json<LoginResponse>)), AuthAPIError> {
-    let auth_cookie = match generate_auth_cookie(email) {
-        Ok(cookie) => cookie,
-        Err(e) => return Err(AuthAPIError::UnexpectedError(e)),
-    };
+    let auth_cookie = generate_auth_cookie(email).map_err(|e| AuthAPIError::UnexpectedError(e))?;
 
     let updated_jar = jar.add(auth_cookie);
 

--- a/auth-service/src/routes/logout.rs
+++ b/auth-service/src/routes/logout.rs
@@ -12,17 +12,17 @@ use crate::{
 pub async fn logout(
     State(state): State<AppState>,
     jar: CookieJar,
-) -> (CookieJar, Result<impl IntoResponse, AuthAPIError>) {
+) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
     let cookie = match jar.get(JWT_COOKIE_NAME) {
         Some(cookie) => cookie,
-        None => return (jar, Err(AuthAPIError::MissingToken)),
+        None => return Err(AuthAPIError::MissingToken),
     };
 
     // Validate token
     let token = SecretString::new(cookie.value().to_owned().into_boxed_str());
     let _ = match validate_token(&token, state.banned_token_store.clone()).await {
         Ok(claims) => claims,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidToken)),
+        Err(_) => return Err(AuthAPIError::InvalidToken),
     };
 
     // Add token to banned list
@@ -33,11 +33,11 @@ pub async fn logout(
         .add_token(token.to_owned())
         .await
     {
-        return (jar, Err(AuthAPIError::UnexpectedError(e.into())));
+        return Err(AuthAPIError::UnexpectedError(e.into()));
     }
 
     // Remove jwt cookie
     let jar = jar.remove(cookie::Cookie::from(JWT_COOKIE_NAME));
 
-    (jar, Ok(StatusCode::OK))
+    Ok((jar, StatusCode::OK))
 }

--- a/auth-service/src/routes/logout.rs
+++ b/auth-service/src/routes/logout.rs
@@ -13,28 +13,22 @@ pub async fn logout(
     State(state): State<AppState>,
     jar: CookieJar,
 ) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
-    let cookie = match jar.get(JWT_COOKIE_NAME) {
-        Some(cookie) => cookie,
-        None => return Err(AuthAPIError::MissingToken),
-    };
+    let cookie = jar.get(JWT_COOKIE_NAME).ok_or(AuthAPIError::MissingToken)?;
 
     // Validate token
     let token = SecretString::new(cookie.value().to_owned().into_boxed_str());
-    let _ = match validate_token(&token, state.banned_token_store.clone()).await {
-        Ok(claims) => claims,
-        Err(_) => return Err(AuthAPIError::InvalidToken),
-    };
+    validate_token(&token, state.banned_token_store.clone())
+        .await
+        .map_err(|_| AuthAPIError::InvalidToken)?;
 
     // Add token to banned list
-    if let Err(e) = state
+    state
         .banned_token_store
         .write()
         .await
         .add_token(token.to_owned())
         .await
-    {
-        return Err(AuthAPIError::UnexpectedError(e.into()));
-    }
+        .map_err(|e| AuthAPIError::UnexpectedError(e.into()))?;
 
     // Remove jwt cookie
     let jar = jar.remove(cookie::Cookie::from(JWT_COOKIE_NAME));

--- a/auth-service/src/routes/verify_2fa.rs
+++ b/auth-service/src/routes/verify_2fa.rs
@@ -14,45 +14,45 @@ pub async fn verify_2fa(
     State(state): State<AppState>,
     jar: CookieJar,
     Json(request): Json<Verify2FARequest>,
-) -> (CookieJar, Result<impl IntoResponse, AuthAPIError>) {
+) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
     let email = match Email::parse(request.email.clone()) {
         Ok(email) => email,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidCredentials)),
+        Err(_) => return Err(AuthAPIError::InvalidCredentials),
     };
 
     let login_attempt_id = match LoginAttemptId::parse(request.login_attempt_id.clone()) {
         Ok(login_attempt_id) => login_attempt_id,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidCredentials)),
+        Err(_) => return Err(AuthAPIError::InvalidCredentials),
     };
 
     let two_fa_code = match TwoFACode::parse(request.two_fa_code) {
         Ok(two_fa_code) => two_fa_code,
-        Err(_) => return (jar, Err(AuthAPIError::InvalidCredentials)),
+        Err(_) => return Err(AuthAPIError::InvalidCredentials),
     };
 
     let mut two_fa_code_store = state.two_fa_code_store.write().await;
 
     let code_tuple = match two_fa_code_store.get_code(&email).await {
         Ok(code_tuple) => code_tuple,
-        Err(_) => return (jar, Err(AuthAPIError::IncorrectCredentials)),
+        Err(_) => return Err(AuthAPIError::IncorrectCredentials),
     };
 
     if !code_tuple.0.eq(&login_attempt_id) || !code_tuple.1.eq(&two_fa_code) {
-        return (jar, Err(AuthAPIError::IncorrectCredentials));
+        return Err(AuthAPIError::IncorrectCredentials);
     }
 
     if let Err(e) = two_fa_code_store.remove_code(&email).await {
-        return (jar, Err(AuthAPIError::UnexpectedError(e.into())));
+        return Err(AuthAPIError::UnexpectedError(e.into()));
     }
 
     let cookie = match generate_auth_cookie(&email) {
         Ok(cookie) => cookie,
-        Err(e) => return (jar, Err(AuthAPIError::UnexpectedError(e))),
+        Err(e) => return Err(AuthAPIError::UnexpectedError(e)),
     };
 
     let updated_jar = jar.add(cookie);
 
-    (updated_jar, Ok(()))
+    Ok((updated_jar, ()))
 }
 
 #[derive(Debug, Deserialize)]

--- a/auth-service/src/routes/verify_2fa.rs
+++ b/auth-service/src/routes/verify_2fa.rs
@@ -15,40 +15,33 @@ pub async fn verify_2fa(
     jar: CookieJar,
     Json(request): Json<Verify2FARequest>,
 ) -> Result<(CookieJar, impl IntoResponse), AuthAPIError> {
-    let email = match Email::parse(request.email.clone()) {
-        Ok(email) => email,
-        Err(_) => return Err(AuthAPIError::InvalidCredentials),
-    };
+    let email =
+        Email::parse(request.email.clone()).map_err(|_| AuthAPIError::InvalidCredentials)?;
 
-    let login_attempt_id = match LoginAttemptId::parse(request.login_attempt_id.clone()) {
-        Ok(login_attempt_id) => login_attempt_id,
-        Err(_) => return Err(AuthAPIError::InvalidCredentials),
-    };
+    let login_attempt_id = LoginAttemptId::parse(request.login_attempt_id.clone())
+        .map_err(|_| AuthAPIError::InvalidCredentials)?;
 
-    let two_fa_code = match TwoFACode::parse(request.two_fa_code) {
-        Ok(two_fa_code) => two_fa_code,
-        Err(_) => return Err(AuthAPIError::InvalidCredentials),
-    };
+    let two_fa_code =
+        TwoFACode::parse(request.two_fa_code).map_err(|_| AuthAPIError::InvalidCredentials)?;
 
     let mut two_fa_code_store = state.two_fa_code_store.write().await;
 
-    let code_tuple = match two_fa_code_store.get_code(&email).await {
-        Ok(code_tuple) => code_tuple,
-        Err(_) => return Err(AuthAPIError::IncorrectCredentials),
-    };
+    let code_tuple = two_fa_code_store
+        .get_code(&email)
+        .await
+        .map_err(|_| AuthAPIError::IncorrectCredentials)?;
 
     if !code_tuple.0.eq(&login_attempt_id) || !code_tuple.1.eq(&two_fa_code) {
         return Err(AuthAPIError::IncorrectCredentials);
     }
 
-    if let Err(e) = two_fa_code_store.remove_code(&email).await {
-        return Err(AuthAPIError::UnexpectedError(e.into()));
-    }
+    two_fa_code_store
+        .remove_code(&email)
+        .await
+        .map_err(|e| AuthAPIError::UnexpectedError(e.into()))?;
 
-    let cookie = match generate_auth_cookie(&email) {
-        Ok(cookie) => cookie,
-        Err(e) => return Err(AuthAPIError::UnexpectedError(e)),
-    };
+    let cookie =
+        generate_auth_cookie(&email).map_err(|e| AuthAPIError::UnexpectedError(e.into()))?;
 
     let updated_jar = jar.add(cookie);
 


### PR DESCRIPTION
What does this PR do?
Updates the return types for the login and logout route functions, as addressed in #37.

Why the Dockerfile changes? 
`cargo-chef`'s dependency `cargo-platform@0.3.3` requires `rustc 1.91`, so the build failed on `rust:1.90-alpine`. Bumped to `1.91` and added `--locked` to pin `cargo-chef` to its lockfile, preventing future dependency resolution surprises.

What are the related ClickUp changes?
- Update login route 
[Update return type](https://app.clickup.com/9015495369/v/dc/8cnv2p9-24955/8cnv2p9-44495?block=block-f93db204-5fe9-4c18-b593-4b1832ebc99c)
[Update return type](https://app.clickup.com/9015495369/v/dc/8cnv2p9-24955/8cnv2p9-44495?block=block-1dbea2db-2d90-46d9-b43a-e004e4a9872c)
[Update return type](https://app.clickup.com/9015495369/v/dc/8cnv2p9-24955/8cnv2p9-44495?block=block-722f94fd-e92a-40cf-b3a1-cde88a71225c)