### PR TITLE
Main: Update alpine version

### DIFF
--- a/app-service/Dockerfile
+++ b/app-service/Dockerfile
@@ -1,8 +1,8 @@
 # Start with image that has the Rust toolchain installed
-FROM rust:1.90-alpine AS chef
+FROM rust:1.91-alpine AS chef
 USER root
 # Add cargo-chef to cache dependencies
-RUN apk add --no-cache musl-dev & cargo install cargo-chef
+RUN apk add --no-cache musl-dev && cargo install cargo-chef --locked
 WORKDIR /app
 
 FROM chef AS planner

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,8 +1,8 @@
 # Start with image that has the Rust toolchain installed
-FROM rust:1.90-alpine AS chef
+FROM rust:1.91-alpine AS chef
 USER root
 # Add cargo-chef to cache dependencies
-RUN apk add --no-cache musl-dev & cargo install cargo-chef
+RUN apk add --no-cache musl-dev && cargo install cargo-chef --locked
 WORKDIR /app
 
 FROM chef AS planner


### PR DESCRIPTION
Why the Dockerfile changes? 
`cargo-chef`'s dependency `cargo-platform@0.3.3` requires `rustc 1.91`, so the build failed on `rust:1.90-alpine`. Bumped to `1.91` and added `--locked` to pin `cargo-chef` to its lockfile, preventing future dependency resolution surprises.